### PR TITLE
Writes data to SD card within loop

### DIFF
--- a/experiments/accelerometer_capture_simple/accelerometer_capture_simple.ino
+++ b/experiments/accelerometer_capture_simple/accelerometer_capture_simple.ino
@@ -1,0 +1,56 @@
+#include <DFRobot_BMX160.h>
+#include <SPI.h>
+#include <SD.h>
+#include <SDLogger.h>
+
+#define CHIP_SELECT               4
+#define FILE_NAME                 "OTO"
+String  DELIM =                   ",";
+
+DFRobot_BMX160 bmx160;
+String flushableString = "\n";
+SDLogger logger = NULL;
+String filesep = "End of write";
+
+
+void setup() {
+ if (bmx160.begin() != true){
+    digitalWrite(LED_BUILTIN, HIGH);
+    while(1);
+  }
+
+   logger = SDLogger(CHIP_SELECT);
+  if (logger.beginLogFile(FILE_NAME) != true){
+    digitalWrite(LED_BUILTIN, HIGH);
+    while(1);
+  }
+  
+  String fieldHeader = "Time(s)";
+  fieldHeader += DELIM + "ax(m/s^2)" + DELIM + "ay(m/s^2)" + DELIM + "az(m/s^2)";
+  fieldHeader += DELIM + "wx(g)" + DELIM + "wy(g)" + DELIM + "wz(g)";
+  fieldHeader += DELIM + "hx(uT)" + DELIM + "hy(uT)" + DELIM + "hz(uT)";
+  logger.log(fieldHeader);
+
+}
+
+String getDataLog() {
+  sBmx160SensorData_t Omagn, Ogyro, Oaccel;
+  bmx160.getAllData(&Omagn, &Ogyro, &Oaccel);
+
+  String dataString = millis() + DELIM;
+  dataString += String(Oaccel.x) + DELIM + String(Oaccel.y) + DELIM + String(Oaccel.z) + DELIM;
+  dataString += String(Ogyro.x) + DELIM + String(Ogyro.y) + DELIM + String(Ogyro.z) + DELIM;
+  dataString += String(Omagn.x) + DELIM + String(Omagn.y) + DELIM + String(Omagn.z); 
+  return dataString;
+}
+
+
+void loop() {
+  for (int i = 0; i < 175; i++){
+  flushableString += getDataLog() + "\n";
+  delay(49);
+  }
+  logger.log(flushableString);
+  flushableString = "";
+  return;
+}


### PR DESCRIPTION
    The write to the SD card was occurring within an interrupt which resulted
    in more and more inaccurate millis() timestamps as time went on.
    The writes in this commit occur in the main loop, which ensures that each
    chunk of data written (every 175 lines of data collected) has accurate
    millis() stamps regardless of how long the write takes.

    Resolves: #21